### PR TITLE
Implement CubQ.dequeue_ack/2 and CubDB.pop_ack/2

### DIFF
--- a/lib/cubq.ex
+++ b/lib/cubq.ex
@@ -32,13 +32,13 @@ defmodule CubQ do
   CubQ.dequeue(pid)
   #=> {:ok, :two}
 
-  # When there are no more elements in the queue, `dequeue/1` returns `nil`:
+  # When there are no more items in the queue, `dequeue/1` returns `nil`:
 
   CubQ.dequeue(pid)
   #=> nil
   ```
 
-  Note that elements can be any Elixir (or Erlang) term:
+  Note that items can be any Elixir (or Erlang) term:
 
   ```
   CubQ.enqueue(pid, %SomeStruct{foo: "bar"})
@@ -48,7 +48,7 @@ defmodule CubQ do
   #=> {:ok, %SomeStruct{foo: "bar"}}
   ```
 
-  The queue is actually double-ended, so elements can be prepended too:
+  The queue is actually double-ended, so items can be prepended too:
 
   ```
   CubQ.enqueue(pid, :one)
@@ -78,7 +78,7 @@ defmodule CubQ do
   CubQ.pop(pid)
   #=> {:ok, :one}
 
-  # When there are no more elements in the stack, `pop/1` returns `nil`:
+  # When there are no more items in the stack, `pop/1` returns `nil`:
 
   CubQ.pop(pid)
   #=> nil
@@ -93,16 +93,18 @@ defmodule CubQ do
   defmodule State do
     @type t :: %CubQ.State{
             db: GenServer.server(),
-            queue: term
+            queue: term,
+            pending_acks: %{}
           }
 
     @enforce_keys [:db, :queue]
-    defstruct [:db, :queue]
+    defstruct [:db, :queue, pending_acks: %{}]
   end
 
   @gen_server_options [:name, :timeout, :debug, :spawn_opt, :hibernate_after]
 
-  @type element :: term
+  @type item :: term
+  @opaque ack_id :: {term, reference, number, :start | :end}
   @type option :: {:db, GenServer.server()} | {:queue, term}
 
   @spec start_link([option | GenServer.option()]) :: GenServer.on_start()
@@ -140,12 +142,12 @@ defmodule CubQ do
     GenServer.start(__MODULE__, options, gen_server_options)
   end
 
-  @spec enqueue(GenServer.server(), element) :: :ok | {:error, term}
+  @spec enqueue(GenServer.server(), item) :: :ok | {:error, term}
 
   @doc """
-  Inserts an element at the end of the queue.
+  Inserts an item at the end of the queue.
 
-  The element can be any Elixir (or Erlang) term.
+  The item can be any Elixir (or Erlang) term.
 
   ## Example:
 
@@ -160,16 +162,16 @@ defmodule CubQ do
   #=> {:ok, :one}
   ```
   """
-  def enqueue(pid, element) do
-    GenServer.call(pid, {:enqueue, element})
+  def enqueue(pid, item) do
+    GenServer.call(pid, {:enqueue, item})
   end
 
-  @spec dequeue(GenServer.server()) :: {:ok, element} | nil | {:error, term}
+  @spec dequeue(GenServer.server()) :: {:ok, item} | nil | {:error, term}
 
   @doc """
-  Removes an element from the beginning of the queue and returns it.
+  Removes an item from the beginning of the queue and returns it.
 
-  It returns `{:ok, element}` if there are elements in the queue, `nil` if the
+  It returns `{:ok, item}` if there are items in the queue, `nil` if the
   queue is empty, and `{:error, cause}` on error.
 
   ## Example:
@@ -192,12 +194,126 @@ defmodule CubQ do
     GenServer.call(pid, :dequeue)
   end
 
-  @spec peek_first(GenServer.server()) :: {:ok, element} | nil | {:error, term}
+  @spec dequeue_ack(GenServer.server(), timeout) :: {:ok, item, ack_id} | nil | {:error, term}
 
   @doc """
-  Returns the element at the beginning of the queue without removing it.
+  Removes an item from the beginning of the queue and returns it, expecting a
+  manual confirmation of its successful processing with `ack/2`. If `ack/2` is
+  not called before `timeout`, the item is put back at the beginning of the
+  queue.
 
-  It returns `{:ok, element}` if there are elements in the queue, `nil` if the
+  The `dequeue_ack/2` function is useful when implementing "at least once"
+  semantics, especially when more than one consumer takes items from the same
+  queue, to ensure that each item is successfully consumed before being
+  discarded.
+
+  The problem is the following: if a consumer took an item with `dequeue/1` and
+  then crashes before processing it, the item would be lost. With
+  `dequeue_ack/2` instead, the item is not immediately removed, but instead
+  atomically transfered to a staging storage. If the consumer successfully
+  processes the item, it can call `ack/2` (acknowledgement) to confirm the
+  success, after which the item is discarded. If `ack/2` is not called within
+  the `timeout` (expressed in milliseconds, 5000 by default), the item is
+  automatically put back to the queue, so it can be dequeued again by a
+  consumer. If the consumer wants to put back the item to the queue immediately,
+  it can also call `nack/2` (negative acknowledgement) explicitly.
+
+  The return value of `dequeue_ack/2` is a 3-tuple: `{:ok, item, ack_id}`.
+  The `ack_id` is the argument that must be passed to `ack/2` or `nack/2` to
+  confirm the successful (or insuccessful) consumption of the item.
+
+  Note that `dequeue_ack/2` performs its operation in an atomic and durable way,
+  so even if the `CubQ` process crashes, after restarting it will still
+  re-insert the items pending acknowledgement in the queue after the timeout
+  elapses.  After restarting though, the timeouts are also restarted, so the
+  effective time before the item goes back to the queue can be larger than the
+  original timeout.
+
+  In case of timeout or negative acknowledgement, the item is put back in the
+  queue from the start, so while global ordering cannot be enforced in case of
+  items being put back to the queue, the items will be ready to be dequeued
+  again immediately after being back to the queue.
+
+  ## Example
+
+  ```
+  CubQ.enqueue(pid, :one)
+  #=> :ok
+
+  CubQ.enqueue(pid, :two)
+  #=> :ok
+
+  {:ok, item, ack_id} = CubQ.dequeue_ack(pid, 3000)
+  #=> {:ok, :one, ack_id}
+
+  # More items can be now taken from the queue
+  CubQ.dequeue(pid)
+  #=> {:ok, :two}
+
+  # If 3 seconds elapse without `ack` being called, or `nack` is called,
+  # the item `:one` would be put back to the queue, so it can be dequeued
+  # again:
+  CubQ.nack(pid, ack_id)
+  #=> :ok
+
+  {:ok, item, ack_id} = CubQ.dequeue_ack(pid, 3000)
+  #=> {:ok, :one, ack_id}
+
+  # When successful consumption is confirmed by calling `ack`, the item
+  # is finally discarded and won't be put back in the queue anymore:
+  CubQ.ack(pid, ack_id)
+  #=> :ok
+  ```
+  """
+  def dequeue_ack(pid, timeout \\ 5000) do
+    GenServer.call(pid, {:dequeue_ack, timeout})
+  end
+
+  @spec pop_ack(GenServer.server(), timeout) :: {:ok, item, ack_id} | nil | {:error, term}
+
+  @doc """
+  Removes an item from the end of the queue and returns it, expecting a manual
+  confirmation of its successful processing with `ack/2`. If `ack/2` is not
+  called before `timeout`, the item is put back at the end of the queue.
+
+  See the documentation for `dequeue_ack/2` for more details: the `pop_ack/2`
+  function works in the same way as `dequeue_ack/2`, but with stack semantics
+  instead of queue semantics.
+  """
+  def pop_ack(pid, timeout \\ 5000) do
+    GenServer.call(pid, {:pop_ack, timeout})
+  end
+
+  @spec ack(GenServer.server(), ack_id) :: :ok | {:error, term}
+
+  @doc """
+  Positively acknowledges the successful consumption of an item taken with
+  `dequeue_ack/2` or `pop_ack/2`.
+
+  See the documentation for `dequeue_ack/2` for more details.
+  """
+  def ack(pid, ack_id) do
+    GenServer.call(pid, {:ack, ack_id})
+  end
+
+  @spec nack(GenServer.server(), ack_id) :: :ok | {:error, term}
+
+  @doc """
+  Negatively acknowledges an item taken with `dequeue_ack/2` or `pop_ack/2`,
+  causing it to be put back in the queue.
+
+  See the documentation for `dequeue_ack/2` for more details.
+  """
+  def nack(pid, ack_id) do
+    GenServer.call(pid, {:nack, ack_id})
+  end
+
+  @spec peek_first(GenServer.server()) :: {:ok, item} | nil | {:error, term}
+
+  @doc """
+  Returns the item at the beginning of the queue without removing it.
+
+  It returns `{:ok, item}` if there are items in the queue, `nil` if the
   queue is empty, and `{:error, cause}` on error.
 
   ## Example:
@@ -220,21 +336,21 @@ defmodule CubQ do
     GenServer.call(pid, :peek_first)
   end
 
-  @spec append(GenServer.server(), element) :: :ok | {:error, term}
+  @spec append(GenServer.server(), item) :: :ok | {:error, term}
 
   @doc """
   Same as `enqueue/2`
   """
-  def append(pid, element) do
-    enqueue(pid, element)
+  def append(pid, item) do
+    enqueue(pid, item)
   end
 
-  @spec prepend(GenServer.server(), element) :: :ok | {:error, term}
+  @spec prepend(GenServer.server(), item) :: :ok | {:error, term}
 
   @doc """
-  Inserts an element at the beginning of the queue.
+  Inserts an item at the beginning of the queue.
 
-  The element can be any Elixir (or Erlang) term.
+  The item can be any Elixir (or Erlang) term.
 
   ## Example:
 
@@ -252,27 +368,27 @@ defmodule CubQ do
   #=> {:ok, :one}
   ```
   """
-  def prepend(pid, element) do
-    GenServer.call(pid, {:prepend, element})
+  def prepend(pid, item) do
+    GenServer.call(pid, {:prepend, item})
   end
 
-  @spec push(GenServer.server(), element) :: :ok | {:error, term}
+  @spec push(GenServer.server(), item) :: :ok | {:error, term}
 
   @doc """
   Same as `enqueue/2`.
 
   Normally used together with `pop/1` for stack semantics.
   """
-  def push(pid, element) do
-    enqueue(pid, element)
+  def push(pid, item) do
+    enqueue(pid, item)
   end
 
-  @spec pop(GenServer.server()) :: {:ok, element} | nil | {:error, term}
+  @spec pop(GenServer.server()) :: {:ok, item} | nil | {:error, term}
 
   @doc """
-  Removes an element from the end of the queue and returns it.
+  Removes an item from the end of the queue and returns it.
 
-  It returns `{:ok, element}` if there are elements in the queue, `nil` if the
+  It returns `{:ok, item}` if there are items in the queue, `nil` if the
   queue is empty, and `{:error, cause}` on error.
 
   ## Example:
@@ -295,12 +411,12 @@ defmodule CubQ do
     GenServer.call(pid, :pop)
   end
 
-  @spec peek_last(GenServer.server()) :: {:ok, element} | nil | {:error, term}
+  @spec peek_last(GenServer.server()) :: {:ok, item} | nil | {:error, term}
 
   @doc """
-  Returns the element at the end of the queue without removing it.
+  Returns the item at the end of the queue without removing it.
 
-  It returns `{:ok, element}` if there are elements in the queue, `nil` if the
+  It returns `{:ok, item}` if there are items in the queue, `nil` if the
   queue is empty, and `{:error, cause}` on error.
 
   ## Example:
@@ -326,9 +442,9 @@ defmodule CubQ do
   @spec delete_all(GenServer.server(), pos_integer) :: :ok | {:error, term}
 
   @doc """
-  Deletes all elements from the queue.
+  Deletes all items from the queue.
 
-  The elements are deleted in batches, and the size of the batch can be
+  The items are deleted in batches, and the size of the batch can be
   specified as the optional second argument.
   """
   def delete_all(pid, batch_size \\ 100) do
@@ -342,13 +458,24 @@ defmodule CubQ do
   def init(options) do
     db = Keyword.fetch!(options, :db)
     queue = Keyword.fetch!(options, :queue)
-    {:ok, %State{db: db, queue: queue}}
+    {:ok, %State{db: db, queue: queue}, {:continue, nil}}
   end
 
   @impl true
 
-  def handle_call({:enqueue, element}, _from, state = %State{db: db, queue: queue}) do
-    reply = Queue.enqueue(db, queue, element)
+  def handle_continue(_continue, state = %State{db: db, queue: queue}) do
+    pending_acks =
+      Enum.reduce(Queue.get_pending_acks!(db, queue), %{}, fn {key, {_, timeout}}, map ->
+        Map.put(map, key, schedule_ack_timeout(key, timeout))
+      end)
+
+    {:noreply, %State{state | pending_acks: pending_acks}}
+  end
+
+  @impl true
+
+  def handle_call({:enqueue, item}, _from, state = %State{db: db, queue: queue}) do
+    reply = Queue.enqueue(db, queue, item)
     {:reply, reply, state}
   end
 
@@ -372,13 +499,95 @@ defmodule CubQ do
     {:reply, reply, state}
   end
 
-  def handle_call({:prepend, element}, _from, state = %State{db: db, queue: queue}) do
-    reply = Queue.prepend(db, queue, element)
+  def handle_call({:prepend, item}, _from, state = %State{db: db, queue: queue}) do
+    reply = Queue.prepend(db, queue, item)
     {:reply, reply, state}
   end
 
   def handle_call({:delete_all, batch_size}, _from, state = %State{db: db, queue: queue}) do
     reply = Queue.delete_all(db, queue, batch_size)
     {:reply, reply, state}
+  end
+
+  def handle_call({:dequeue_ack, timeout}, _from, state) do
+    %State{db: db, queue: queue, pending_acks: pending_acks} = state
+    reply = Queue.dequeue_ack(db, queue, timeout)
+
+    state =
+      case reply do
+        {:ok, _, ack_id} ->
+          ref = schedule_ack_timeout(ack_id, timeout)
+          %State{state | pending_acks: Map.put(pending_acks, ack_id, ref)}
+
+        _ ->
+          state
+      end
+
+    {:reply, reply, state}
+  end
+
+  def handle_call({:pop_ack, timeout}, _from, state) do
+    %State{db: db, queue: queue, pending_acks: pending_acks} = state
+    reply = Queue.pop_ack(db, queue, timeout)
+
+    state =
+      case reply do
+        {:ok, _, ack_id} ->
+          ref = schedule_ack_timeout(ack_id, timeout)
+          %State{state | pending_acks: Map.put(pending_acks, ack_id, ref)}
+
+        _ ->
+          state
+      end
+
+    {:reply, reply, state}
+  end
+
+  def handle_call({:ack, ack_id}, _from, state) do
+    %State{db: db, queue: queue, pending_acks: pending_acks} = state
+
+    with :ok <- Queue.ack(db, queue, ack_id) do
+      case Map.pop(pending_acks, ack_id) do
+        {nil, _} ->
+          {:reply, {:error, :not_found}, state}
+
+        {timer, pending_acks} ->
+          Process.cancel_timer(timer)
+          {:reply, :ok, %State{state | pending_acks: pending_acks}}
+      end
+    else
+      reply -> {:reply, reply, state}
+    end
+  end
+
+  def handle_call({:nack, ack_id}, _from, state) do
+    %State{db: db, queue: queue, pending_acks: pending_acks} = state
+
+    with :ok <- Queue.nack(db, queue, ack_id) do
+      case Map.pop(pending_acks, ack_id) do
+        {nil, _} ->
+          {:reply, {:error, :not_found}, state}
+
+        {timer, pending_acks} ->
+          Process.cancel_timer(timer)
+          {:reply, :ok, %State{state | pending_acks: pending_acks}}
+      end
+    else
+      reply -> {:reply, reply, state}
+    end
+  end
+
+  @impl true
+
+  def handle_info({:ack_timeout, ack_id}, state) do
+    %State{db: db, queue: queue, pending_acks: pending_acks} = state
+    :ok = Queue.nack(db, queue, ack_id)
+    {:noreply, %State{state | pending_acks: Map.delete(pending_acks, ack_id)}}
+  end
+
+  @spec schedule_ack_timeout(ack_id, timeout) :: reference
+
+  defp schedule_ack_timeout(ack_id, timeout) do
+    Process.send_after(self(), {:ack_timeout, ack_id}, timeout)
   end
 end

--- a/lib/cubq/queue.ex
+++ b/lib/cubq/queue.ex
@@ -2,46 +2,46 @@ defmodule CubQ.Queue do
   @moduledoc false
 
   @typep key :: {term, number}
-  @typep entry :: {key, CubQ.element()}
+  @typep entry :: {key, CubQ.item()}
   @typep select_option ::
            {:min_key, key}
            | {:max_key, key}
            | {:reverse, boolean}
            | {:pipe, [{:take, pos_integer}]}
 
-  @spec enqueue(GenServer.server(), term, CubQ.element()) :: :ok | {:error, term}
+  @spec enqueue(GenServer.server(), term, CubQ.item()) :: :ok | {:error, term}
 
-  def enqueue(db, queue, element) do
+  def enqueue(db, queue, item) do
     conditions = select_conditions(queue)
 
     case get_entry(db, queue, [{:reverse, true} | conditions]) do
       {:ok, {{_queue, n}, _value}} ->
-        CubDB.put(db, {queue, n + 1}, element)
+        CubDB.put(db, {queue, n + 1}, item)
 
       nil ->
-        CubDB.put(db, {queue, 0}, element)
+        CubDB.put(db, {queue, 0}, item)
 
       other ->
         other
     end
   end
 
-  @spec prepend(GenServer.server(), term, CubQ.element()) :: :ok | {:error, term}
+  @spec prepend(GenServer.server(), term, CubQ.item()) :: :ok | {:error, term}
 
-  def prepend(db, queue, element) do
+  def prepend(db, queue, item) do
     case get_entry(db, queue, select_conditions(queue)) do
       {:ok, {{_queue, n}, _value}} ->
-        CubDB.put(db, {queue, n - 1}, element)
+        CubDB.put(db, {queue, n - 1}, item)
 
       nil ->
-        CubDB.put(db, {queue, 0}, element)
+        CubDB.put(db, {queue, 0}, item)
 
       other ->
         other
     end
   end
 
-  @spec dequeue(GenServer.server(), term) :: {:ok, CubQ.element()} | nil | {:error, term}
+  @spec dequeue(GenServer.server(), term) :: {:ok, CubQ.item()} | nil | {:error, term}
 
   def dequeue(db, queue) do
     case get_entry(db, queue, select_conditions(queue)) do
@@ -53,7 +53,7 @@ defmodule CubQ.Queue do
     end
   end
 
-  @spec pop(GenServer.server(), term) :: {:ok, CubQ.element()} | nil | {:error, term}
+  @spec pop(GenServer.server(), term) :: {:ok, CubQ.item()} | nil | {:error, term}
 
   def pop(db, queue) do
     conditions = select_conditions(queue)
@@ -67,7 +67,7 @@ defmodule CubQ.Queue do
     end
   end
 
-  @spec peek_first(GenServer.server(), term) :: {:ok, CubQ.element()} | nil | {:error, term}
+  @spec peek_first(GenServer.server(), term) :: {:ok, CubQ.item()} | nil | {:error, term}
 
   def peek_first(db, queue) do
     case get_entry(db, queue, select_conditions(queue)) do
@@ -79,7 +79,7 @@ defmodule CubQ.Queue do
     end
   end
 
-  @spec peek_last(GenServer.server(), term) :: {:ok, CubQ.element()} | nil | {:error, term}
+  @spec peek_last(GenServer.server(), term) :: {:ok, CubQ.item()} | nil | {:error, term}
 
   def peek_last(db, queue) do
     conditions = select_conditions(queue)
@@ -104,14 +104,86 @@ defmodule CubQ.Queue do
       {:ok, []} ->
         :ok
 
-      {:ok, elements} when is_list(elements) ->
-        keys = Enum.map(elements, fn {key, _value} -> key end)
+      {:ok, items} when is_list(items) ->
+        keys = Enum.map(items, fn {key, _value} -> key end)
 
         with :ok <- CubDB.delete_multi(db, keys),
              do: delete_all(db, queue, batch_size)
 
       {:error, error} ->
         {:error, error}
+    end
+  end
+
+  @spec dequeue_ack(GenServer.server(), term, timeout) ::
+          {:ok, CubQ.item(), CubQ.ack_id()} | nil | {:error, term}
+
+  def dequeue_ack(db, queue, timeout) do
+    case get_entry(db, queue, select_conditions(queue)) do
+      {:ok, entry} ->
+        stage_item(db, queue, entry, timeout, :start)
+
+      other ->
+        other
+    end
+  end
+
+  @spec pop_ack(GenServer.server(), term, timeout) ::
+          {:ok, CubQ.item(), CubQ.ack_id()} | nil | {:error, term}
+
+  def pop_ack(db, queue, timeout) do
+    conditions = select_conditions(queue)
+
+    case get_entry(db, queue, [{:reverse, true} | conditions]) do
+      {:ok, entry} ->
+        stage_item(db, queue, entry, timeout, :end)
+
+      other ->
+        other
+    end
+  end
+
+  @spec ack(GenServer.server(), term, CubQ.ack_id()) :: :ok | {:error, term}
+
+  def ack(db, _queue, ack_id) do
+    CubDB.delete(db, ack_id)
+  end
+
+  @spec nack(GenServer.server(), term, CubQ.ack_id()) :: :ok | {:error, term}
+
+  def nack(db, queue, ack_id) do
+    # item can be requeued at the start or at the end of the queue
+    {conditions, increment} = case ack_id do
+      {_, _, _, :end} ->
+        {[{:reverse, true} | select_conditions(queue)], 1}
+
+      _ ->
+        {select_conditions(queue), -1}
+    end
+
+    case get_entry(db, queue, conditions) do
+      {:ok, {{_queue, n}, _value}} ->
+        with {:ok, nil} <- commit_nack(db, queue, ack_id, n + increment), do: :ok
+
+      nil ->
+        with {:ok, nil} <- commit_nack(db, queue, ack_id, 0), do: :ok
+
+      other ->
+        other
+    end
+  end
+
+  @spec get_pending_acks!(GenServer.server(), term) :: [
+          {CubQ.ack_id(), {CubQ.item(), timeout}}
+        ]
+
+  def get_pending_acks!(db, queue) do
+    case CubDB.select(db,
+      min_key: {queue, nil, 0, 0},
+      max_key: {queue, [], nil, []}
+    ) do
+      {:ok, entries} -> entries
+      {:error, error} -> raise(error)
     end
   end
 
@@ -135,5 +207,36 @@ defmodule CubQ.Queue do
       {:error, error} ->
         {:error, error}
     end
+  end
+
+  @spec stage_item(GenServer.server(), term, entry, timeout, :start | :end) ::
+          {:ok, CubQ.item(), term} | nil | {:error, term}
+
+  defp stage_item(db, queue, entry, timeout, requeue_pos) do
+    {key, item} = entry
+    ack_id = {queue, make_ref(), :rand.uniform_real(), requeue_pos}
+
+    case CubDB.get_and_update_multi(db, [], fn _ ->
+           {nil, %{ack_id => {item, timeout}}, [key]}
+         end) do
+      {:ok, nil} ->
+        {:ok, item, ack_id}
+
+      other ->
+        other
+    end
+  end
+
+  @spec commit_nack(GenServer.server(), term, CubQ.ack_id(), number) ::
+          {:ok, term} | {:error, term}
+
+  defp commit_nack(db, queue, ack_id, n) do
+    CubDB.get_and_update_multi(db, [ack_id], fn
+      %{^ack_id => {item, _timeout}} ->
+        {nil, %{{queue, n} => item}, [ack_id]}
+
+      _ ->
+        {nil, %{}, []}
+    end)
   end
 end


### PR DESCRIPTION
This is useful when implementing "at least once" semantics with multiple
consumers of a queue.

Basically, `CubQ.dequeue_ack(pid, timeout)` (or the symmetrical
`CubQ.pop_ack(pid, timeout)`) dequeues an item, but expects the consumer
to explicitly call `ack/2` or `nack/2` to confirm that the item was
successfully consumed or not, before the `timeout` elapses.

If `nack/2` is called, or if the timeout elapses before `ack/2` is
called, the item is put back in the queue, so it can be dequeued again
by a consumer. This is done in a durable and atomic way: even if the
`CubQ` process exits, when restarted it will still keep track of the
pending acks, and put the items back to the queue if not acked on time.